### PR TITLE
Fix invalid input in month rendering

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -69,6 +69,11 @@ export function getRenderedWeekRows(start, date, weekStartsOn) {
 
   let renderedWeeks = 0;
 
+  if(isAfter(startDate, date)) {
+    console.log('d was after date');
+    startDate = date;
+  }
+
   // Loop from start to date in monthly steps
   for (let d = startDate; !isInCurrentMonth(d, date); d.setMonth(d.getMonth() + 1)) {
     let numOfWeeks = getWeeksInMonth(d.getMonth(), d.getFullYear(), weekStartsOn);

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -74,11 +74,6 @@ export function getRenderedWeekRows(start, date, weekStartsOn) {
     startDate = date;
   }
 
-  if(isAfter(startDate, date)) {
-    console.log('d was after date');
-    startDate = date;
-  }
-
   // Loop from start to date in monthly steps
   for (let d = startDate; !isInCurrentMonth(d, date); d.setMonth(d.getMonth() + 1)) {
     let numOfWeeks = getWeeksInMonth(d.getMonth(), d.getFullYear(), weekStartsOn);

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -74,6 +74,11 @@ export function getRenderedWeekRows(start, date, weekStartsOn) {
     startDate = date;
   }
 
+  if(isAfter(startDate, date)) {
+    console.log('d was after date');
+    startDate = date;
+  }
+
   // Loop from start to date in monthly steps
   for (let d = startDate; !isInCurrentMonth(d, date); d.setMonth(d.getMonth() + 1)) {
     let numOfWeeks = getWeeksInMonth(d.getMonth(), d.getFullYear(), weekStartsOn);


### PR DESCRIPTION
In the hystreet project problems occur when the startDate is dated before the compared Date. We´re now catching this behaviour.